### PR TITLE
Fix: Run build before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
       - run: npm ci
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -42,6 +43,7 @@ jobs:
           cache: npm
           registry-url: https://npm.pkg.github.com
       - run: npm ci
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1 (2023-09-27)
+
+- 77b3c33 docs: Use object nomenclature
+- a135a75 fix: Run build script before publish 🤦🏻‍♂️
+
 ## 2.0.0 (2023-09-27)
 
 - 46460b8 chore: Add publish workflow

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You've got a couple options for adding TemplateTemplate to your project:
 
 ## Usage
 
-TemplateTemplate takes two arguments: a reference to a `<template>` element and a hash of `insertions` defining the content to insert into the `<template>`.
+TemplateTemplate takes two arguments: a reference to a `<template>` element and an object of `insertions` defining the content to insert into the `<template>`.
 
 ### Basic
 
@@ -69,7 +69,7 @@ A basic example, inserting a row into a `<table>`:
 </script>
 ```
 
-In the example above, a reference to the `<template>` element is passed to TemplateTemplate using [`document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector). The `insertions` hash is a map of key/value pairs where the key (e.g. `'.name'`) is a valid [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) and the `value` (e.g. `'TemplateTemplate'`) is a string of text to insert into the selected node.
+In the example above, a reference to the `<template>` element is passed to TemplateTemplate using [`document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector). The `insertions` argument an object whose keys (e.g. `'.name'`) are valid [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) and whose values (e.g. `'TemplateTemplate'`) are strings of text to insert into the selected node.
 
 ### Advanced
 
@@ -140,8 +140,8 @@ TemplateTemplate('#row-template', {
   // index in the array as the `textContent` for the node. If this value is
   // `null`, TemplateTemplate skips setting the node's `textContent`.
   //
-  // The second index is a hash of key/value pairs which are added to the node
-  // as HTML attributes.
+  // The second index is an object whose properties are added to the node as
+  // HTML attributes.
   tr: [null, {
     class: 'project',
     id: 'project-cashcash'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jgarber/templatetemplate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jgarber/templatetemplate",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@jgarber/eslint-config": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jgarber/templatetemplate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A very small JavaScript <template> manipulation library.",
   "keywords": [
     "dom",


### PR DESCRIPTION
The packages published as v2.0.0 didn't include the `dist` folder because I never ran `npm run build` in the publish workflow jobs. 🤦🏻 

This PR corrects that (and updates the docs a bit)!