### PR TITLE
Add upload coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,3 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
-      - uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -1,0 +1,21 @@
+name: Upload coverage
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage:
+    name: Upload coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - uses: paambaati/codeclimate-action@v5.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
The CI workflow only runs on PRs and when publishing a release (called by the release workflow).

This new upload coverage workflow will run only on pushes to `main` and will re-run the test suite and upload coverage.